### PR TITLE
Fix- (#24) Download Graph image for small screen 

### DIFF
--- a/src/app/user/[username]/page.tsx
+++ b/src/app/user/[username]/page.tsx
@@ -25,11 +25,24 @@ function UserContributionContent({ username }: { username: string }) {
   const dataFetchedRef = useRef(false);
 
   const handleDownload = useCallback(async () => {
-    if (downloadDivRef.current === null) return;
-    
+    if (!downloadDivRef.current) return;
+
     toast.promise(
       async () => {
-        const dataUrl = await toPng(downloadDivRef.current!);
+        const graphElement=downloadDivRef.current!;
+        const originalWidth =graphElement.style.width;
+        const originalOverflow =graphElement.style.overflow;
+        graphElement.style.width="1200px"; 
+        graphElement.style.overflow="visible";
+
+        await new Promise(resolve => setTimeout(resolve, 300));      
+        const dataUrl = await toPng(graphElement,{
+          backgroundColor: "#1a1a1a"
+        });
+
+        graphElement.style.width = originalWidth;
+        graphElement.style.overflow = originalOverflow;
+
         const link = document.createElement('a');
         link.download = `${username}-github-contributions.png`;
         link.href = dataUrl;


### PR DESCRIPTION
Fixes -  #24 

added functionality to download graph for small screen sizes by temporary increasing the size of the graph.

## Screenshot

![image](https://github.com/user-attachments/assets/ee73d5da-6097-4d3f-8e43-bfc3a09fab95)


![image](https://github.com/user-attachments/assets/e6a2db89-c121-4b3c-93ad-bf3d95a3fd94)
